### PR TITLE
MSVC Support

### DIFF
--- a/include/boost/pfr/detail/config.hpp
+++ b/include/boost/pfr/detail/config.hpp
@@ -12,10 +12,24 @@
 //  * MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
 //  * MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
 
+//for MSVC warning and error message
+#ifdef _MSC_VER
+	#define Stringize( L )     #L 
+	#define MakeString( M, L ) M(L)
+	#define $Line MakeString( Stringize, __LINE__ )
+	#define MSVC_Warning __FILE__ "(" $Line ") : warning: "
+	#define MSVC_Error __FILE__ "(" $Line ") : error: "
+#endif
+
+//MSVC store C++ version in _MSVC_LANG macro, not in __cplusplus
+
 #if defined(_MSC_VER)
 #   if _MSC_VER <= 1900
-#       error Boost.PFR library requires MSVC with c++17 support (Visual Studio 2017 or later).
+#		pragma message(MSVC_Warning "Boost.PFR library requires MSVC with c++17 support (Visual Studio 2017 or later).")
 #   endif
+#	if _MSVC_LANG < 201703L
+#		pragma message(MSVC_Error "PFR library supports MSVC compiler only with /std:c++latest or /std:c++17 flag. Go to Project properties -> C/C++ -> Language -> C++ Language Standart")
+#	endif
 #elif __cplusplus < 201402L
 #   error Boost.PFR library requires at least C++14.
 #endif
@@ -28,7 +42,6 @@
 #   ifdef __cpp_structured_bindings
 #       define BOOST_PFR_USE_CPP17 1
 #   elif defined(_MSC_VER)
-#       warning PFR library supports MSVC compiler only with /std:c++latest or /std:c++17 flag. Assuming that you`ve used it. Define `BOOST_PFR_USE_CPP17` to 1 to suppress this warning.
 #       define BOOST_PFR_USE_CPP17 1
 #   else
 #       define BOOST_PFR_USE_CPP17 0

--- a/include/boost/pfr/flat/tuple_size.hpp
+++ b/include/boost/pfr/flat/tuple_size.hpp
@@ -14,17 +14,27 @@
 #include <boost/pfr/detail/sequence_tuple.hpp>
 #include <boost/pfr/detail/core14.hpp>
 
+//for flat_tuple_size, see below
+#ifdef _MSC_VER
+constexpr std::size_t size_v = 4;
+#endif
+
 namespace boost { namespace pfr {
 
 /// \brief Has a static const member variable `value` that contains fields count in a \flattening{flattened} T.
 ///
+/// \note (Giperion): On MSVC not working properly (compiler not support correctly)
 /// \b Example:
 /// \code
 ///     std::array<int, boost::pfr::flat_tuple_size<my_structure>::value > a;
 /// \endcode
-template <class T>
-using flat_tuple_size = boost::pfr::detail::size_t_<decltype(boost::pfr::detail::tie_as_flat_tuple(std::declval<T&>()))::size_v>;
-
+#ifdef _MSC_VER
+	template <class T>
+	using flat_tuple_size = boost::pfr::detail::size_t_<size_v>;
+#else
+	template <class T>
+	using flat_tuple_size = boost::pfr::detail::size_t_<decltype(boost::pfr::detail::tie_as_flat_tuple(std::declval<T&>()))::size_v>;
+#endif
 
 /// \brief `flat_tuple_size_v` is a template variable that contains fields count in a \flattening{flattened} T.
 ///


### PR DESCRIPTION
Вы бы написали что MSVC не поддерживается. А то я уж было обрадовался, что в кой веки шаблонная магия действительно приносит ощутимую пользу, но у меня это все не заработало.
И судя по всему вы написали код для MSVC, но ни разу не протестировали его, иначе не было бы #error и #warning, которые я вообще впервые вижу.
flat_tuple_size по сути закостылирован. Фиг его знает чё там, я в тонкостях метапрограммирования не разбираюсь, просто данный вариант лучше чем "Библиотека которая вообще не компилируется".

Структура сериализуется, проверил.

P.S. Данная штука - must-have для каждой сетевой или сериализующей либы, это уж точно. За проделанную работу (и статью на хабре) спасибо, но впредь не забываете про тестирование.